### PR TITLE
[KAIZEN-0] tweak av ressursbruk

### DIFF
--- a/.nais/nais-q0.yaml
+++ b/.nais/nais-q0.yaml
@@ -26,10 +26,10 @@ spec:
   resources:
     limits:
       cpu: 3000m
-      memory: 768Mi
+      memory: 1024Mi
     requests:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 400m
+      memory: 768Mi
   ingresses:
     - https://modiacontextholder-q0.nais.preprod.local/modiacontextholder
     - https://modapp-q0.adeo.no/modiacontextholder

--- a/.nais/nais-q1.yaml
+++ b/.nais/nais-q1.yaml
@@ -26,10 +26,10 @@ spec:
   resources:
     limits:
       cpu: 3000m
-      memory: 768Mi
+      memory: 1024Mi
     requests:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 400m
+      memory: 768Mi
   ingresses:
     - https://modiacontextholder-q1.nais.preprod.local/modiacontextholder
     - https://modapp-q1.adeo.no/modiacontextholder

--- a/.nais/nais-q6.yaml
+++ b/.nais/nais-q6.yaml
@@ -26,10 +26,10 @@ spec:
   resources:
     limits:
       cpu: 3000m
-      memory: 768Mi
+      memory: 1024Mi
     requests:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 400m
+      memory: 768Mi
   ingresses:
     - https://modiacontextholder-q6.nais.preprod.local/modiacontextholder
     - https://modapp-q6.adeo.no/modiacontextholder

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -26,10 +26,10 @@ spec:
   resources:
     limits:
       cpu: 3000m
-      memory: 768Mi
+      memory: 1024Mi
     requests:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 400m
+      memory: 768Mi
   ingresses:
     - https://modiacontextholder.nais.adeo.no/modiacontextholder
     - https://modapp.adeo.no/modiacontextholder


### PR DESCRIPTION
Nåsituasjon minne;
![image](https://user-images.githubusercontent.com/1413417/77996402-d60b2a80-732d-11ea-8683-c997918f1132.png)

Nåsituasjon cpu;
![image](https://user-images.githubusercontent.com/1413417/77996424-ddcacf00-732d-11ea-8f56-4d627036dac8.png)

Gir poddene litt mer minne og cpu slik at vi unngår pod-thrashing