### PR TITLE
Legger til støtte for preprod-urlen dev.adeo.no.

### DIFF
--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -32,6 +32,7 @@ spec:
       memory: 768Mi
   ingresses:
     - https://modiacontextholder-{{ namespace }}.nais.preprod.local/modiacontextholder
+    - https://modiacontextholder-{{ namespace }}.dev.adeo.no/modiacontextholder
     - https://modapp-{{ namespace }}.adeo.no/modiacontextholder
     - https://app-{{ namespace }}.adeo.no/modiacontextholder
   replicas:


### PR DESCRIPTION
Denne url-en er anbefalt i nais-docen:
https://doc.nais.io/clusters/on-premises#dev-fss