### PR TITLE
[KAIZEN-0] skru av refreshing av token

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -84,10 +84,6 @@ spec:
       value: "fpsak-frontend-p"
     - name: ISSO_DISCOVERY_URL
       value: "https://isso.adeo.no/isso/oauth2/.well-known/openid-configuration"
-    - name: ISSO_REFRESH_URL
-      value: "https://app.adeo.no/veilarblogin/api/openam-refresh"
-    - name: MODIA_REFRESH_URL
-      value: "https://app.adeo.no/modialogin/api/refresh"
     - name: LOGINSERVICE_OIDC_DISCOVERYURI
       value: "https://login.microsoftonline.com/navno.onmicrosoft.com/.well-known/openid-configuration"
     - name: AAD_V2_DISCOVERURI

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -86,10 +86,6 @@ spec:
       value: "fpsak-frontend-{{ namespace }}"
     - name: ISSO_DISCOVERY_URL
       value: "https://isso-q.adeo.no/isso/oauth2/.well-known/openid-configuration"
-    - name: ISSO_REFRESH_URL
-      value: "https://app-{{ namespace }}.adeo.no/veilarblogin/api/openam-refresh"
-    - name: MODIA_REFRESH_URL
-      value: "https://app-{{ namespace }}.adeo.no/modialogin/api/refresh"
     - name: LOGINSERVICE_OIDC_DISCOVERYURI
       value: "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/.well-known/openid-configuration"
     - name: AAD_V2_DISCOVERURI

--- a/src/main/java/no/nav/sbl/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/sbl/config/ApplicationConfig.java
@@ -41,9 +41,7 @@ public class ApplicationConfig {
     private static final String azureADV2DiscoveryUrl = EnvironmentUtils.getRequiredProperty("AAD_V2_DISCOVERURI");
 
     private static final String issoClientId = EnvironmentUtils.getRequiredProperty("ISSO_CLIENT_ID");
-    private static final String issoRefreshUrl = EnvironmentUtils.getRequiredProperty("ISSO_REFRESH_URL");
     private static final String modiaClientId = EnvironmentUtils.getRequiredProperty("MODIA_CLIENT_ID");
-    private static final String modiaRefreshUrl = EnvironmentUtils.getRequiredProperty("MODIA_REFRESH_URL");
     private static final String fpsakClientId = EnvironmentUtils.getRequiredProperty("FPSAK_CLIENT_ID");
     private static final String azureADClientId = EnvironmentUtils.getRequiredProperty("LOGINSERVICE_OIDC_CLIENTID");
     private static final String veilarbloginAADClientId = EnvironmentUtils.getRequiredProperty("VEILARBLOGIN_AAD_CLIENT_ID");
@@ -57,17 +55,13 @@ public class ApplicationConfig {
                 .withClientId(issoClientId)
                 .withDiscoveryUrl(issoDiscoveryUrl)
                 .withIdTokenCookieName(Constants.OPEN_AM_ID_TOKEN_COOKIE_NAME)
-                .withUserRole(UserRole.INTERN)
-                .withRefreshUrl(issoRefreshUrl)
-                .withRefreshTokenCookieName(Constants.REFRESH_TOKEN_COOKIE_NAME);
+                .withUserRole(UserRole.INTERN);
 
         OidcAuthenticatorConfig openAmModia = new OidcAuthenticatorConfig()
                 .withClientId(modiaClientId)
                 .withDiscoveryUrl(issoDiscoveryUrl)
                 .withIdTokenCookieName("modia_ID_token")
-                .withUserRole(UserRole.INTERN)
-                .withRefreshUrl(modiaRefreshUrl)
-                .withRefreshTokenCookieName("modia_refresh_token");
+                .withUserRole(UserRole.INTERN);
 
         OidcAuthenticatorConfig openAmFpsak = new OidcAuthenticatorConfig()
                 .withClientId(fpsakClientId)


### PR DESCRIPTION
modiacontextholder er en felles-tjeneste som godtar tokens fra mange utsteder,
dette skaper problemer med dagens OidcAuthFilter når man forsøker å fornye tokens som er utløpt.

konseptuelt sett så faller fornying av tokens også litt utenfor modiacontextholder sitt ansvarsområde,
og bør heller håndteres av BFFs, frontend-proxy eller andre mer nærliggende baksystem.