### PR TITLE
[PROD][KAIZEN-0] fikse statuskode når person ikke blir funnet i pdl

### DIFF
--- a/src/main/java/no/nav/sbl/service/PdlService.kt
+++ b/src/main/java/no/nav/sbl/service/PdlService.kt
@@ -3,6 +3,7 @@ package no.nav.sbl.service
 import io.ktor.client.request.header
 import io.ktor.util.KtorExperimentalAPI
 import io.vavr.control.Try
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import no.nav.common.sts.SystemUserTokenProvider
 import no.nav.common.utils.EnvironmentUtils
@@ -21,8 +22,11 @@ class PdlService(private val stsService: SystemUserTokenProvider) {
 
     fun hentIdent(fnr: String): Try<String> = Try.of {
         runBlocking {
-            HentIdent(graphQLClient)
-                .execute(HentIdent.Variables(fnr), userTokenHeaders)
+            val response = HentIdent(graphQLClient).execute(HentIdent.Variables(fnr), userTokenHeaders)
+            if (response.errors != null) {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, response.errors.toString())
+            }
+            response
                 .data
                 ?.hentIdenter
                 ?.identer


### PR DESCRIPTION
NotFoundException kommer fra jaxrs, og blir ikke håndtert riktig etter byttet til spring-boot.

Samtidig svelget vi unna alle feil fra PDL, slik at evt feilsøking var nærmest umulig for andre. Dette er nå også fikset ved at vi kaster en 400 BadRequest om pdl rapporterer om feil.