### PR TITLE
[PROD][KAIZEN-0] bruke systemtoken for uthenting av aktørid

### DIFF
--- a/src/main/java/no/nav/sbl/service/PdlService.kt
+++ b/src/main/java/no/nav/sbl/service/PdlService.kt
@@ -22,7 +22,7 @@ class PdlService(private val stsService: SystemUserTokenProvider) {
 
     fun hentIdent(fnr: String): Try<String> = Try.of {
         runBlocking {
-            val response = HentIdent(graphQLClient).execute(HentIdent.Variables(fnr), userTokenHeaders)
+            val response = HentIdent(graphQLClient).execute(HentIdent.Variables(fnr), systemTokenHeaders)
             if (response.errors != null) {
                 throw ResponseStatusException(HttpStatus.BAD_REQUEST, response.errors.toString())
             }
@@ -36,12 +36,11 @@ class PdlService(private val stsService: SystemUserTokenProvider) {
         }
     }
 
-    private var userTokenHeaders: HeadersBuilder = {
+    private var systemTokenHeaders: HeadersBuilder = {
         val systemuserToken: String = stsService.systemUserToken
-        val userToken: String = AuthContextService.requireIdToken()
 
         header("Nav-Consumer-Token", "Bearer $systemuserToken")
-        header("Authorization", "Bearer $userToken")
+        header("Authorization", "Bearer $systemuserToken")
         header("Tema", "GEN")
     }
 }


### PR DESCRIPTION
PDL støtter ikke AzureADv1 tokens, og jobber med å legge til støtte for AzureADv2 tokens.
Så per i dag kan vi ikke videreføre userToken til pdl.

Siden vi bare henter ut aktørId gitt ett fødselsnummer, så er det sannsynligvis innafor å bare bruke systemtoken her.
Tilgangskontroll til FNR må uansett gjøres av systemet hvor internarbeidsflatedecoratøren er embedded, og authentisering av saksbehandler er fortsatt gjort av modiacontextholder.

Vi er sådan sikre på at det er en innlogget saksbehandler som gjøre spørringen.