### PR TITLE
[KAIZEN-0] eksponere appen til gcp

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -31,6 +31,7 @@ spec:
       cpu: 400m
       memory: 768Mi
   ingresses:
+    - https://modiacontextholder.prod-fss-pub.nais.io/modiacontextholder
     - https://modiacontextholder.intern.nav.no/modiacontextholder
     - https://modiacontextholder.nais.adeo.no/modiacontextholder
     - https://modapp.adeo.no/modiacontextholder

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -31,6 +31,7 @@ spec:
       cpu: 400m
       memory: 768Mi
   ingresses:
+    - https://modiacontextholder-{{ namespace }}.dev-fss-pub.nais.io/modiacontextholder
     - https://modiacontextholder-{{ namespace }}.dev.intern.nav.no/modiacontextholder
     - https://modiacontextholder-{{ namespace }}.nais.preprod.local/modiacontextholder
     - https://modiacontextholder-{{ namespace }}.dev.adeo.no/modiacontextholder


### PR DESCRIPTION
bruken av wonderwall hos konsumenter gjør at de må bruke en proxy for å gjøre kall til modiacontextholder.

For å støtte dette må appen derfor åpnes opp for kall fra gcp
