### PR TITLE
[PROD][KAIZEN-0] eksponere appen til gcp

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -31,6 +31,7 @@ spec:
       cpu: 400m
       memory: 768Mi
   ingresses:
+    - https://modiacontextholder.prod-fss-pub.nais.io/modiacontextholder
     - https://modiacontextholder.intern.nav.no/modiacontextholder
     - https://modiacontextholder.nais.adeo.no/modiacontextholder
     - https://modapp.adeo.no/modiacontextholder

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -113,6 +113,8 @@ spec:
       value: "d9f767f1-89a0-413a-9c18-368eb3f752e9"
     - name: REKRUTTERINGSBISTAND_CONTAINER_CLIENTID
       value: "539183b6-56d3-4a65-9e01-75c980b2cd58"
+    - name: ARBEIDSSOKERREGISTRERING_VEILEDER_CLIENTID
+      value: "e875bd94-d6a1-43e8-9f4f-aca9faa23992"
     - name: APP_ENVIRONMENT_NAME
       value: "p"
     - name: AAREG_URL

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -115,6 +115,8 @@ spec:
       value: "300fd59d-c575-473a-bd6a-9b0fd51b28ad"
     - name: REKRUTTERINGSBISTAND_CONTAINER_CLIENTID
       value: "19069abf-30aa-4a8d-90fd-caaacdc45166"
+    - name: ARBEIDSSOKERREGISTRERING_VEILEDER_CLIENTID
+      value: "e875bd94-d6a1-43e8-9f4f-aca9faa23992"
     - name: APP_ENVIRONMENT_NAME
       value: "{{ namespace }}"
     - name: AAREG_URL

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -31,6 +31,7 @@ spec:
       cpu: 400m
       memory: 768Mi
   ingresses:
+    - https://modiacontextholder-{{ namespace }}.dev-fss-pub.nais.io/modiacontextholder
     - https://modiacontextholder-{{ namespace }}.dev.intern.nav.no/modiacontextholder
     - https://modiacontextholder-{{ namespace }}.nais.preprod.local/modiacontextholder
     - https://modiacontextholder-{{ namespace }}.dev.adeo.no/modiacontextholder

--- a/src/main/java/no/nav/sbl/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/sbl/config/ApplicationConfig.java
@@ -60,6 +60,7 @@ public class ApplicationConfig {
     private static final String sosialhjelpModiaClientId = EnvironmentUtils.getRequiredProperty("SOSIALHJELP_MODIA_CLIENTID");
     private static final String spinnsynFrontendInterneClientId = EnvironmentUtils.getRequiredProperty("SPINNSYN_FRONTEND_INTERNE_CLIENTID");
     private static final String rekrutteringsbistandContainerClientId = EnvironmentUtils.getRequiredProperty("REKRUTTERINGSBISTAND_CONTAINER_CLIENTID");
+    private static final String arbeidssokerregistreringVeilederClientId = EnvironmentUtils.getRequiredProperty("ARBEIDSSOKERREGISTRERING_VEILEDER_CLIENTID");
 
     @Bean
     public FilterRegistrationBean corsFilterRegistration() {
@@ -101,7 +102,7 @@ public class ApplicationConfig {
                 .withUserRole(UserRole.INTERN);
 
         OidcAuthenticatorConfig azureAdV2 = new OidcAuthenticatorConfig()
-                .withClientIds(asList(syfoFinnfastlegeClientId, syfoSyfomodiapersonClientId, syfoSyfomoteoversiktClientId, syfoSyfooversiktClientId, syfoSmregClientId, sosialhjelpModiaClientId, veilarbloginAADClientId, syfoSmmanuellClientId, syfoSmregNewClientId, spinnsynFrontendInterneClientId, rekrutteringsbistandContainerClientId))
+                .withClientIds(asList(syfoFinnfastlegeClientId, syfoSyfomodiapersonClientId, syfoSyfomoteoversiktClientId, syfoSyfooversiktClientId, syfoSmregClientId, sosialhjelpModiaClientId, veilarbloginAADClientId, syfoSmmanuellClientId, syfoSmregNewClientId, spinnsynFrontendInterneClientId, rekrutteringsbistandContainerClientId, arbeidssokerregistreringVeilederClientId))
                 .withDiscoveryUrl(azureADV2DiscoveryUrl)
                 .withIdTokenCookieName(Constants.AZURE_AD_ID_TOKEN_COOKIE_NAME)
                 .withUserRole(UserRole.INTERN);


### PR DESCRIPTION
bruken av wonderwall hos konsumenter gjør at de må bruke en proxy for å gjøre kall til modiacontextholder.

For å støtte dette må appen derfor åpnes opp for kall fra gcp
