### PR TITLE
[KAIZEN-0] sette opp salesforce redirect

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -136,3 +136,5 @@ spec:
       value: "https://arbeid-og-inntekt.nais.adeo.no"
     - name: REDIS_HOST
       value: "modiacontextholder-redis.personoversikt.svc.nais.local"
+    - name: SALESFORCE_URL
+      value: "https://navdialog.lightning.force.com"

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -138,3 +138,5 @@ spec:
       value: "https://arbeid-og-inntekt-q1.dev.adeo.no"
     - name: REDIS_HOST
       value: "modiacontextholder-redis.personoversikt.svc.nais.local"
+    - name: SALESFORCE_URL
+      value: "https://navdialog--sit2.lightning.force.com"


### PR DESCRIPTION
gjøres fordi man må sjekke med unleash hvorvidt en bruker skal sendes med bruker i kontekst (e.g er med i piloten).
Dette gjøres fordi Salesforce ikke støtter urler med bruker i kontekst for brukere utenfor piloten
