### PR TITLE
[OPP-1490] Skifte pub fra docker til ghcr.io

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/modiacontextholder:${{ github.sha }}
+  IMAGE: ghcr.io/${{ github.repository }}/modiacontextholder:${{ github.sha }}
   CI: true
   TZ: Europe/Oslo
 
@@ -53,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker build --tag ${IMAGE} .
-          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
           docker push ${IMAGE}
 
   deploy-qa:


### PR DESCRIPTION
docker.pkg.github.com er deprecated, erstattet med ghcr.io