### PR TITLE
[KAIZEN-0] øke maks header-størrelse

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 spring.main.banner-mode=off
 server.servlet.context-path=/modiacontextholder
 
+# Default 8KB, men ser tilfeller av at dette feiler i produksjon med feilmeldingen "Request header is too large"
+server.max-http-header-size=16KB
+
 management.endpoint.metrics.enabled=true
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.base-path=/internal


### PR DESCRIPTION
i noen tilfeller kan det komme requester med masse cookies,
for å støtte disse så økes maks størrelsen på headere
til 16KB fra 8KB.
