### PR TITLE
[KAIZEN-0] fjerne ubrukt konfig for rekrutteringsbistand

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -144,8 +144,6 @@ spec:
       value: "ee2a7796-113a-4637-89d1-49d29843e833"
     - name: SPINNSYN_FRONTEND_INTERNE_CLIENTID
       value: "d9f767f1-89a0-413a-9c18-368eb3f752e9"
-    - name: REKRUTTERINGSBISTAND_CONTAINER_CLIENTID
-      value: "cf4fe4de-5085-4257-adbd-9130f99f3769"
     - name: APP_ENVIRONMENT_NAME
       value: "p"
     - name: AAREG_URL

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -146,8 +146,6 @@ spec:
       value: "6f661f36-1adb-42c3-9e10-294a10007880"
     - name: SPINNSYN_FRONTEND_INTERNE_CLIENTID
       value: "300fd59d-c575-473a-bd6a-9b0fd51b28ad"
-    - name: REKRUTTERINGSBISTAND_CONTAINER_CLIENTID
-      value: "19069abf-30aa-4a8d-90fd-caaacdc45166"
     - name: APP_ENVIRONMENT_NAME
       value: "{{ namespace }}"
     - name: AAREG_URL

--- a/src/main/java/no/nav/sbl/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/sbl/config/ApplicationConfig.java
@@ -52,7 +52,6 @@ public class ApplicationConfig {
     private static final String syfoSmmanuellClientId = EnvironmentUtils.getRequiredProperty("SYFO_SMMANUELL_CLIENTID");
     private static final String sosialhjelpModiaClientId = EnvironmentUtils.getRequiredProperty("SOSIALHJELP_MODIA_CLIENTID");
     private static final String spinnsynFrontendInterneClientId = EnvironmentUtils.getRequiredProperty("SPINNSYN_FRONTEND_INTERNE_CLIENTID");
-    private static final String rekrutteringsbistandContainerClientId = EnvironmentUtils.getRequiredProperty("REKRUTTERINGSBISTAND_CONTAINER_CLIENTID");
 
     /**
      * Azure verdiene er automatisk injected til poden siden vi har lagt til azure-konfig i nais-yaml
@@ -82,7 +81,7 @@ public class ApplicationConfig {
                 .withUserRole(UserRole.INTERN);
 
         OidcAuthenticatorConfig azureAdV2 = new OidcAuthenticatorConfig()
-                .withClientIds(asList(syfoFinnfastlegeClientId, syfoSyfomodiapersonClientId, syfoSyfomoteoversiktClientId, syfoSyfooversiktClientId, syfoSmregClientId, sosialhjelpModiaClientId, veilarbloginAADClientId, syfoSmmanuellClientId, syfoSmregNewClientId, spinnsynFrontendInterneClientId, rekrutteringsbistandContainerClientId))
+                .withClientIds(asList(syfoFinnfastlegeClientId, syfoSyfomodiapersonClientId, syfoSyfomoteoversiktClientId, syfoSyfooversiktClientId, syfoSmregClientId, sosialhjelpModiaClientId, veilarbloginAADClientId, syfoSmmanuellClientId, syfoSmregNewClientId, spinnsynFrontendInterneClientId))
                 .withDiscoveryUrl(azureADV2DiscoveryUrl)
                 .withIdTokenCookieName(Constants.AZURE_AD_ID_TOKEN_COOKIE_NAME)
                 .withUserRole(UserRole.INTERN);


### PR DESCRIPTION
teamet har byttet til OBO-token, så clientId kan nå fjernes
