### PR TITLE
Allow obo for sosialhjelp-modia-oidc-auth-proxy

### DIFF
--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -110,6 +110,9 @@ spec:
         - application: syfooversikt
           namespace: teamsykefravr
           cluster: dev-fss
+        - application: sosialhjelp-modia-oidc-auth-proxy
+          namespace: teamdigisos
+          cluster: dev-fss
   secureLogs:
     enabled: true
   env:


### PR DESCRIPTION
I første omgang kun i dev