### PR TITLE
remove SOSIALHJELP_MODIA_CLIENTID

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -150,8 +150,6 @@ spec:
       value: "cd1456a1-b2cd-449d-8fc1-ffe55fe63b61"
     - name: SYFO_SYFOOVERSIKT_CLIENTID
       value: "4fca3a52-4540-4690-8a81-240ace253839"
-    - name: SOSIALHJELP_MODIA_CLIENTID
-      value: "ee2a7796-113a-4637-89d1-49d29843e833"
     - name: APP_ENVIRONMENT_NAME
       value: "p"
     - name: AAREG_URL

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -152,8 +152,6 @@ spec:
       value: "5bfe761b-8fcb-4b89-81a0-f37bee456af5"
     - name: SYFO_SYFOOVERSIKT_CLIENTID
       value: "6db2c887-7c46-49a8-a6a5-26adec81a145"
-    - name: SOSIALHJELP_MODIA_CLIENTID
-      value: "6f661f36-1adb-42c3-9e10-294a10007880"
     - name: APP_ENVIRONMENT_NAME
       value: "{{ namespace }}"
     - name: AAREG_URL

--- a/src/main/java/no/nav/sbl/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/sbl/config/ApplicationConfig.java
@@ -45,7 +45,6 @@ public class ApplicationConfig {
     private static final String syfoSyfomodiapersonClientId = EnvironmentUtils.getRequiredProperty("SYFO_SYFOMODIAPERSON_CLIENTID");
     private static final String syfoSyfomoteoversiktClientId = EnvironmentUtils.getRequiredProperty("SYFO_SYFOMOTEOVERSIKT_CLIENTID");
     private static final String syfoSyfooversiktClientId = EnvironmentUtils.getRequiredProperty("SYFO_SYFOOVERSIKT_CLIENTID");
-    private static final String sosialhjelpModiaClientId = EnvironmentUtils.getRequiredProperty("SOSIALHJELP_MODIA_CLIENTID");
     /**
      * Azure verdiene er automatisk injected til poden siden vi har lagt til azure-konfig i nais-yaml
      */
@@ -74,7 +73,7 @@ public class ApplicationConfig {
                 .withUserRole(UserRole.INTERN);
 
         OidcAuthenticatorConfig azureAdV2 = new OidcAuthenticatorConfig()
-                .withClientIds(asList(syfoFinnfastlegeClientId, syfoSyfomodiapersonClientId, syfoSyfomoteoversiktClientId, syfoSyfooversiktClientId, sosialhjelpModiaClientId))
+                .withClientIds(asList(syfoFinnfastlegeClientId, syfoSyfomodiapersonClientId, syfoSyfomoteoversiktClientId, syfoSyfooversiktClientId))
                 .withDiscoveryUrl(azureADV2DiscoveryUrl)
                 .withIdTokenCookieName(Constants.AZURE_AD_ID_TOKEN_COOKIE_NAME)
                 .withUserRole(UserRole.INTERN);


### PR DESCRIPTION
Sosialhjelp-modia bruker nå OBO (sosialhjelp-modia-oidc-auth-proxy), så disse clientId'ene trengs ikke lengre