### PR TITLE
Tilpasser for finnfastlege på gcp

### DIFF
--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -149,7 +149,7 @@ spec:
     - name: LOGINSERVICE_OIDC_CLIENTID
       value: "38e07d31-659d-4595-939a-f18dce3446c5"
     - name: SYFO_FINNFASTLEGE_CLIENTID
-      value: "decdb625-ddde-4c4a-9586-f20862b9e1fe"
+      value: "dev-gcp.teamsykefravr.finnfastlege"
     - name: SYFO_SYFOMODIAPERSON_CLIENTID
       value: "897256b4-faa4-474a-aa2e-5f7b5b9c7e16"
     - name: SYFO_SYFOMOTEOVERSIKT_CLIENTID


### PR DESCRIPTION
Disse clientId'ene vil endre verdi når app'ene migreres til gcp. Tror det er bedre å angi dem på cluster.namespace.app-format (men litt usikker på om det skal være punktum eller kolon i denne konteksten ).

Får teste det ut i dev først. 

Må gjøre tilsvarende tilpasning prod etterpå, men det må merges i forbindelse med at vi switcher over.