### PR TITLE
Gi tilgang til ny rekrutteringsbistand-app

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -94,6 +94,9 @@ spec:
         - application: rekrutteringsbistand-container
           namespace: toi
           cluster: prod-gcp
+        - application: rekrutteringsbistand
+          namespace: toi
+          cluster: prod-gcp
         - application: spinnsyn-frontend-interne
           namespace: flex
           cluster: prod-gcp

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -96,6 +96,9 @@ spec:
         - application: rekrutteringsbistand-container
           namespace: toi
           cluster: dev-gcp
+        - application: rekrutteringsbistand
+          namespace: toi
+          cluster: dev-gcp
         - application: spinnsyn-frontend-interne
           namespace: flex
           cluster: dev-gcp


### PR DESCRIPTION
Vi jobber med å restrukturere Rekrutteringsbistand, og trenger derfor tilgang fra ny app i Nais. Har fremdeles behov for tilgang i `rekrutteringsbistand-container`, så fint om vi kan ha begge tilganger en periode.