### PR TITLE
Allow modiaeventdistribution i redis-med-passord

### DIFF
--- a/.nais/redis-med-passord.yaml
+++ b/.nais/redis-med-passord.yaml
@@ -14,6 +14,7 @@ spec:
     inbound:
       rules:
         - application: modiacontextholder
+        - application: modiaeventdistribution
   image: bitnami/redis:7.2.4
   port: 6379
   replicas: # A single Redis-app doesn't scale


### PR DESCRIPTION
Så en del feil i modiaeventdistribution i dev (q2) med redis-connection, kanskje dette hjelper?