### PR TITLE
Match trailing slash på non-trailing slash paths

### DIFF
--- a/src/main/java/no/nav/sbl/config/WebConfiguration.kt
+++ b/src/main/java/no/nav/sbl/config/WebConfiguration.kt
@@ -1,0 +1,12 @@
+package no.nav.sbl.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+open class WebConfiguration : WebMvcConfigurer {
+    override fun configurePathMatch(configurer: PathMatchConfigurer) {
+        configurer.setUseTrailingSlashMatch(true)
+    }
+}


### PR DESCRIPTION
Spring boot 3 endret default matching av trailing slash. Vi har fortsatt
mange konsumenter som gjør litt av hvert, så dette har skapt litt
issues. Denne commiten bruker en deprecated option til å midlertidig
fikse det i alle fall.
