### PR TITLE
Sett database connection pool size rikig mtp pods

### DIFF
--- a/src/main/java/no/nav/sbl/config/DatabaseConfig.kt
+++ b/src/main/java/no/nav/sbl/config/DatabaseConfig.kt
@@ -39,7 +39,7 @@ open class DatabaseConfig {
             config.username = EnvironmentUtils.getRequiredProperty(MODIACONTEXTHOLDERDB_USERNAME)
             config.password = EnvironmentUtils.getRequiredProperty(MODIACONTEXTHOLDERDB_PASSWORD)
         }
-        config.maximumPoolSize = 180
+        config.maximumPoolSize = 45
         config.minimumIdle = 5
 
         val dataSource = HikariDataSource(config)


### PR DESCRIPTION
Klassisk blunder med at jeg ikke tok hensyn til antall replicas, så connection pool limiten ble jo
multiplisert med antall pods og gikk fort over limiten.

Med litt napkin math med metrikker under max load på connection duration og peak request rate
trenger vi ca 40 connections aktive for at ingen requests trenger å vente på connections. Med 45 per
replica burde det være mer enn nok, og med max 4 replicas er vi under limiten på 200 connections til
databasen
