### PR TITLE
Bruk annen URL for AAREG uten aktiv bruker

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -158,6 +158,8 @@ spec:
       value: "{{ namespace }}"
     - name: AAREG_URL
       value: "https://arbeid-og-inntekt-q2.dev-fss-pub.nais.io"
+    - name: AAREG_PUBLIC_URL
+      value: "https://arbeid-og-inntekt-q2.dev.adeo.no"
     - name: REDIS_URI
       value: "$(REDIS_URI_CONTEXTHOLDER)"
     - name: REDIS_USER

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -155,6 +155,8 @@ spec:
       value: "p"
     - name: AAREG_URL
       value: "https://arbeid-og-inntekt.prod-fss-pub.nais.io"
+    - name: AAREG_PUBLIC_URL
+      value: "https://arbeid-og-inntekt.nais.adeo.no"
     - name: REDIS_URI
       value: "redis://modiacontextholder-redis-med-passord:6379"
     - name: SALESFORCE_URL

--- a/src/main/java/no/nav/sbl/rest/RedirectRessurs.kt
+++ b/src/main/java/no/nav/sbl/rest/RedirectRessurs.kt
@@ -25,6 +25,7 @@ class RedirectRessurs
         private val contextService: ContextService,
     ) {
         private val aaRegisteretBaseUrl = EnvironmentUtils.getRequiredProperty("AAREG_URL")
+        private val aaRegisteretPublicUrl = EnvironmentUtils.getRequiredProperty("AAREG_PUBLIC_URL")
         private val salesforceBaseUrl = EnvironmentUtils.getRequiredProperty("SALESFORCE_URL")
         private val client: OkHttpClient = RestClient.baseClient()
         private val log = LoggerFactory.getLogger(RedirectRessurs::class.java)
@@ -36,7 +37,7 @@ class RedirectRessurs
         fun salesforce(): ResponseEntity<Unit> = temporaryRedirect(salesforceBaseUrl)
 
         private fun aaRegisteretUrl(context: RSContext?): String {
-            val aktivBruker: String = context?.aktivBruker ?: return aaRegisteretBaseUrl
+            val aktivBruker: String = context?.aktivBruker ?: return aaRegisteretPublicUrl
             return runCatching {
                 val request =
                     Request


### PR DESCRIPTION
AAREG_URL er en intern ingress når vi kaller fra gcp, så her må vi
returnere den public URLen istedetfor når vi ikke kaller på redirect
APIet.
