### PR TITLE
Legg til scheduled task for WS heartbeat

### DIFF
--- a/src/main/java/no/nav/sbl/config/WebSocketConfiguration.kt
+++ b/src/main/java/no/nav/sbl/config/WebSocketConfiguration.kt
@@ -28,9 +28,8 @@ open class WebSocketConfiguration {
     @Bean
     open fun createWebSocketContainerFactoryBean(): ServletServerContainerFactoryBean {
         val container = ServletServerContainerFactoryBean()
-        // Set idle timeout to 24 hours
-        // The default timeout seems to be 1 minute, which causes some issues on the client side
-        container.maxSessionIdleTimeout = 24 * 60 * 60 * 1000
+        // Set idle timeout to 2 minutes
+        container.maxSessionIdleTimeout = 120 * 1000
 
         return container
     }

--- a/src/main/java/no/nav/sbl/websocket/ContextWebSocketHandler.kt
+++ b/src/main/java/no/nav/sbl/websocket/ContextWebSocketHandler.kt
@@ -1,13 +1,18 @@
 package no.nav.sbl.websocket
 
 import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.web.socket.CloseStatus
+import org.springframework.web.socket.PingMessage
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
 import java.io.IOException
+import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentHashMap
 
+@EnableScheduling
 class ContextWebSocketHandler : TextWebSocketHandler() {
     private val log = LoggerFactory.getLogger(this::class.java)
     private val sessions = ConcurrentHashMap<String, MutableList<WebSocketSession>>()
@@ -51,6 +56,16 @@ class ContextWebSocketHandler : TextWebSocketHandler() {
             when (it) {
                 is IOException -> log.error("Error sending message to websocket", it)
                 is IllegalStateException, is NullPointerException -> log.debug("Session is closed, ignoring message")
+            }
+        }
+    }
+
+    @Scheduled(fixedRate = 30 * 1000)
+    fun heartbeat() {
+        val ping = PingMessage(ByteBuffer.allocate(1))
+        sessions.values.forEach {
+            it.forEach { session ->
+                session.sendMessage(ping)
             }
         }
     }

--- a/src/test/java/no/nav/sbl/MainTest.kt
+++ b/src/test/java/no/nav/sbl/MainTest.kt
@@ -2,7 +2,6 @@ package no.nav.sbl
 
 import no.nav.common.nais.NaisYamlUtils
 import no.nav.common.rest.client.RestClient
-import no.nav.common.test.SystemProperties
 import no.nav.common.test.ssl.SSLTestUtils
 import no.nav.common.test.ssl.TrustAllSSLSocketFactory
 import org.springframework.boot.SpringApplication
@@ -14,10 +13,9 @@ import javax.net.ssl.X509TrustManager
 object MainTest {
     init {
         setupRestClient()
-        SystemProperties.setFrom(".vault.properties")
         val naisConfig =
             NaisYamlUtils.getTemplatedConfig(
-                ".nais/qa-template.yaml",
+                ".nais/dev.yaml",
                 object : HashMap<Any?, Any?>() {
                     init {
                         put("namespace", "q0")


### PR DESCRIPTION
WebSocket serveren sender visst ikke PING heartbeat meldinger by
default til sockets (i motsetning til de fleste andre WebSocket servere).
Så socketen blir lukket hele tiden grunnet inaktivitet og tvinger
klienten til å åpne en ny socket. Forhåpentligvis funker dette og
motvirker problemet.
