### PR TITLE
tiltak-refusjon i accesspolicy

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -136,6 +136,9 @@ spec:
         - application: tiltaksgjennomforing-intern
           namespace: arbeidsgiver
           cluster: prod-gcp
+        - application: tiltak-refusjon-saksbehandler
+          namespace: arbeidsgiver
+          cluster: prod-gcp
   secureLogs:
     enabled: true
   envFrom:


### PR DESCRIPTION
Vi bruker modia context holder i refusjonsløsningen,
og i forbindelse med migrering til v3 tar vi en liten opprydning
her også.