### PR TITLE
Valider med JWTPrincipal

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -54,9 +54,6 @@ spec:
       enabled: true
       allowAllUsers: true
       tenant: trygdeetaten.no
-      claims:
-        extra:
-          - "NAVident"
   accessPolicy:
     outbound:
       external:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ val ktor_version = "2.3.12"
 val kotlin_version = "2.0.20"
 val koin_version = "3.5.6"
 
-val modia_common_version = "1.2024.10.04-11.54-51c1a67b2edb"
+val modia_common_version = "1.2024.10.08-15.26-79dda7914471"
 val nav_common_version = "3.2024.05.23_05.46-2b29fa343e8e"
 val graphql_kotlin_version = "8.0.0"
 val caffeine_version = "3.1.8"

--- a/src/main/kotlin/no/nav/modiacontextholder/config/Configuration.kt
+++ b/src/main/kotlin/no/nav/modiacontextholder/config/Configuration.kt
@@ -1,6 +1,7 @@
 package no.nav.modiacontextholder.config
 
 import io.ktor.http.*
+import io.ktor.server.auth.jwt.*
 import no.nav.common.utils.EnvironmentUtils
 import no.nav.personoversikt.common.ktor.utils.Security
 import no.nav.personoversikt.common.ktor.utils.Security.AuthProviderConfig
@@ -28,6 +29,7 @@ class Configuration(
                 listOf(
                     Security.TokenLocation.Header(HttpHeaders.Authorization),
                 ),
+            useJWTPrincipal = true,
         ),
     val isMock: Boolean = false,
     val redisUri: String = getRequiredConfig("REDIS_URI_CONTEXTHOLDER", defaultValues),


### PR DESCRIPTION
Istedenfor SubjectPrincipal. Dette for å få tilgang til andre claims i
JWT tokenet, som ikke default SubjectPrincipal tilgjengeligjør.
