### PR TITLE
Bruke sharedFlow & ignorer lukkede sessions

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -69,9 +69,6 @@ spec:
           namespace: org
     inbound:
       rules:
-        - application: arbeidssokerregistrering-veileder
-          namespace: paw
-          cluster: dev-gcp
         - application: arbeidssokerregistrering-for-veileder
           cluster: dev-gcp
           namespace: paw
@@ -83,9 +80,6 @@ spec:
           cluster: dev-gcp
         - application: beslutteroversikt
           namespace: obo
-          cluster: dev-gcp
-        - application: smregistrering
-          namespace: teamsykmelding
           cluster: dev-gcp
         - application: syfosmmanuell
           namespace: teamsykmelding

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -72,9 +72,6 @@ spec:
           namespace: org
     inbound:
       rules:
-        - application: arbeidssokerregistrering-veileder
-          namespace: paw
-          cluster: prod-gcp
         - application: arbeidssokerregistrering-for-veileder
           cluster: prod-gcp
           namespace: paw
@@ -86,9 +83,6 @@ spec:
           cluster: prod-gcp
         - application: beslutteroversikt
           namespace: obo
-          cluster: prod-gcp
-        - application: smregistrering
-          namespace: teamsykmelding
           cluster: prod-gcp
         - application: syfosmmanuell
           namespace: teamsykmelding
@@ -111,8 +105,6 @@ spec:
         - application: rekrutteringsbistand
           namespace: toi
           cluster: prod-gcp
-        - application: rekrutteringsbistand-next
-          namespace: toi
         - application: spinnsyn-frontend-interne
           namespace: flex
           cluster: prod-gcp

--- a/src/main/kotlin/no/nav/modiacontextholder/Websocket.kt
+++ b/src/main/kotlin/no/nav/modiacontextholder/Websocket.kt
@@ -1,7 +1,6 @@
 package no.nav.modiacontextholder
 
 import io.ktor.server.application.*
-import io.ktor.server.auth.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.lettuce.core.RedisClient
@@ -13,7 +12,7 @@ import java.time.Duration
 fun Application.setupWebsocket() {
     val redisClient: RedisClient by inject()
     val redisConsumer = setupRedisConsumer(redisClient)
-    val websocketStorage = WebsocketStorage(redisConsumer.getFlow())
+    val websocketStorage = WebsocketStorage(redisConsumer.getFlow(), this)
 
     install(WebSockets) {
         pingPeriod = Duration.ofMinutes(1)


### PR DESCRIPTION
Bruk sharedFlow istedenfor channels for en mer clean approach som er mer
forståelig. Litt usikker på spesifikke forskjeller på de to selv, men
dette er måten anbefalt av Ktor.

Ignorer NullPointerException i sending av WS melding. Oppstår
antakeligvis ved use after free av websocket session. I.e. session
lukkes i det en WS melding skal lukkes i sessionen så session er hentet,
den lukkes i handleren før propageringen forsøker å sende på session.

I tillegg fjerne ubrukte inbound rules i naisfiler.
