### PR TITLE
Konfigurer workergroup thread count

### DIFF
--- a/src/main/kotlin/no/nav/modiacontextholder/Main.kt
+++ b/src/main/kotlin/no/nav/modiacontextholder/Main.kt
@@ -18,7 +18,11 @@ fun main() {
     val configuration = Configuration()
 
     KtorServer
-        .create(Netty, port = 4000) {
+        .create(Netty, port = 4000, configure = {
+            connectionGroupSize = 8
+            workerGroupSize = 8
+            callGroupSize = 16
+        }) {
             modiacontextholderApp(configuration = configuration)
         }.start(wait = true)
 }


### PR DESCRIPTION
Dette er defaultet til antall processorer som getProcessorCount()
returnerer, som i GCP k8s som regel er 1. Det er dog rom for å ha flere
threads aktive i poden som Netty kan utnytte til bedre parallelisme.
Dette burde gjøre appen mer stabil og utnytte ressursene bedre. Taller
er tatt fra lufta/erfaring fra andre team (det viktige er at det er mer
enn 1).
